### PR TITLE
[kafka-broker] copy log4j config as a template and changed the logging behaviour

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,6 +60,9 @@ kafka_broker_systemd_state: started
 kafka_broker_user: cp-kafka
 kafka_broker_zookeeper_chroot_path: null
 kafka_broker_environment: {}
+kafka_broker_log4j_config_file: /etc/kafka/log4j.properties
+kafka_broker_log4j_max_file_size: 100MB
+kafka_broker_log4j_max_number: 3
 
 kafka_connect_distributed_config_config_storage_replication_factor: 3
 kafka_connect_distributed_config_config_storage_topic: connect-configs

--- a/tasks/kafka-broker/main.yml
+++ b/tasks/kafka-broker/main.yml
@@ -48,6 +48,16 @@
   notify: restart kafka
   become: yes
 
+- name: log4j configuration
+  template:
+    src: kafka-broker/log4j.properties.j2
+    dest: "{{ kafka_broker_log4j_config_file }}"
+    mode: 0640
+    owner: "{{ kafka_broker_user }}"
+    group: "{{ kafka_broker_group }}"
+  notify: restart kafka
+  become: yes
+
 - name: Restart broker if needed
   meta: flush_handlers
 

--- a/templates/kafka-broker/log4j.properties.j2
+++ b/templates/kafka-broker/log4j.properties.j2
@@ -1,0 +1,102 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Unspecified loggers and loggers with additivity=true output to server.log and stdout
+# Note that INFO only applies to unspecified loggers, the log level of the child logger is used otherwise
+log4j.rootLogger=INFO, stdout, kafkaAppender
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+log4j.appender.kafkaAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.kafkaAppender.File=${kafka.logs.dir}/server.log
+log4j.appender.kafkaAppender.MaxFileSize={{ kafka_broker_log4j_max_file_size }}
+log4j.appender.kafkaAppender.MaxBackupIndex={{ kafka_broker_log4j_max_number }}
+log4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.kafkaAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+log4j.appender.stateChangeAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.stateChangeAppender.DatePattern=
+log4j.appender.stateChangeAppender.File=${kafka.logs.dir}/state-change.log
+log4j.appender.kafkaAppender.MaxFileSize={{ kafka_broker_log4j_max_file_size }}
+log4j.appender.kafkaAppender.MaxBackupIndex={{ kafka_broker_log4j_max_number }}
+log4j.appender.stateChangeAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.stateChangeAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+log4j.appender.requestAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.requestAppender.DatePattern=
+log4j.appender.requestAppender.File=${kafka.logs.dir}/kafka-request.log
+log4j.appender.kafkaAppender.MaxFileSize={{ kafka_broker_log4j_max_file_size }}
+log4j.appender.kafkaAppender.MaxBackupIndex={{ kafka_broker_log4j_max_number }}
+log4j.appender.requestAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+log4j.appender.cleanerAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.cleanerAppender.DatePattern=
+log4j.appender.cleanerAppender.File=${kafka.logs.dir}/log-cleaner.log
+log4j.appender.kafkaAppender.MaxFileSize={{ kafka_broker_log4j_max_file_size }}
+log4j.appender.kafkaAppender.MaxBackupIndex={{ kafka_broker_log4j_max_number }}
+log4j.appender.cleanerAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.cleanerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+log4j.appender.controllerAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.controllerAppender.DatePattern=
+log4j.appender.controllerAppender.File=${kafka.logs.dir}/controller.log
+log4j.appender.kafkaAppender.MaxFileSize={{ kafka_broker_log4j_max_file_size }}
+log4j.appender.kafkaAppender.MaxBackupIndex={{ kafka_broker_log4j_max_number }}
+log4j.appender.controllerAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.controllerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+log4j.appender.authorizerAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.authorizerAppender.DatePattern=
+log4j.appender.authorizerAppender.File=${kafka.logs.dir}/kafka-authorizer.log
+log4j.appender.kafkaAppender.MaxFileSize={{ kafka_broker_log4j_max_file_size }}
+log4j.appender.kafkaAppender.MaxBackupIndex={{ kafka_broker_log4j_max_number }}
+log4j.appender.authorizerAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+# Change the two lines below to adjust ZK client logging
+log4j.logger.org.I0Itec.zkclient.ZkClient=INFO
+log4j.logger.org.apache.zookeeper=INFO
+
+# Change the two lines below to adjust the general broker logging level (output to server.log and stdout)
+log4j.logger.kafka=INFO
+log4j.logger.org.apache.kafka=INFO
+
+# Change to DEBUG or TRACE to enable request logging
+log4j.logger.kafka.request.logger=WARN, requestAppender
+log4j.additivity.kafka.request.logger=false
+
+# Uncomment the lines below and change log4j.logger.kafka.network.RequestChannel$ to TRACE for additional output
+# related to the handling of requests
+#log4j.logger.kafka.network.Processor=TRACE, requestAppender
+#log4j.logger.kafka.server.KafkaApis=TRACE, requestAppender
+#log4j.additivity.kafka.server.KafkaApis=false
+log4j.logger.kafka.network.RequestChannel$=WARN, requestAppender
+log4j.additivity.kafka.network.RequestChannel$=false
+
+log4j.logger.kafka.controller=TRACE, controllerAppender
+log4j.additivity.kafka.controller=false
+
+log4j.logger.kafka.log.LogCleaner=INFO, cleanerAppender
+log4j.additivity.kafka.log.LogCleaner=false
+
+log4j.logger.state.change.logger=TRACE, stateChangeAppender
+log4j.additivity.state.change.logger=false
+
+# Access denials are logged at INFO level, change to DEBUG to also log allowed accesses
+log4j.logger.kafka.authorizer.logger=INFO, authorizerAppender
+log4j.additivity.kafka.authorizer.logger=false


### PR DESCRIPTION
- rolling (5 files each one 4*100MB files == 2Go maximum)