### PR TITLE
[log4j] stop logging on stdout

### DIFF
--- a/templates/kafka-broker/log4j.properties.j2
+++ b/templates/kafka-broker/log4j.properties.j2
@@ -15,11 +15,7 @@
 
 # Unspecified loggers and loggers with additivity=true output to server.log and stdout
 # Note that INFO only applies to unspecified loggers, the log level of the child logger is used otherwise
-log4j.rootLogger=INFO, stdout, kafkaAppender
-
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.rootLogger=INFO, kafkaAppender
 
 log4j.appender.kafkaAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.kafkaAppender.File=${kafka.logs.dir}/server.log


### PR DESCRIPTION
daemon.log is filled with kafka stuffs that are already on kafka logs (/var/log/kafka)
maybe it's not the right way, tell me what you think
